### PR TITLE
Ensure reset `$output` in smoke test

### DIFF
--- a/tools/run-smoke.rb
+++ b/tools/run-smoke.rb
@@ -12,8 +12,9 @@ def run(f)
   $output = []
   TypeProfiler.type_profile(TypeProfiler::ISeq.compile(f))
   output = $output
-  $output = nil
   output
+ensure
+  $output = nil
 end
 
 files = ARGV


### PR DESCRIPTION
In the smoke test, `puts` displays nothing to capture type data if `$output` is set.

But `$output` is not cleared if the type profiler raises an error. It conceals `puts "# NG: #{ f }"`.

This patch will fix the problem by moving `$output = nil` into ensure clause.


## before


```
$ ./smoke.sh 
# OK: smoke/alias.rb
# OK: smoke/any1.rb
# OK: smoke/any2.rb
# OK: smoke/arguments.rb
# OK: smoke/array-each.rb
# OK: smoke/array-each2.rb
# OK: smoke/array-each3.rb
# OK: smoke/array1.rb
# OK: smoke/array2.rb
# OK: smoke/array3.rb
# OK: smoke/array4.rb
# OK: smoke/array5.rb
# OK: smoke/array6.rb
# OK: smoke/array7.rb
# OK: smoke/array8.rb
# OK: smoke/backtrace.rb
# OK: smoke/block1.rb
# OK: smoke/block11.rb
# OK: smoke/block2.rb
# OK: smoke/block3.rb
# OK: smoke/block4.rb
# OK: smoke/block5.rb
# OK: smoke/block6.rb
# OK: smoke/block8.rb
# OK: smoke/block9.rb
# OK: smoke/case.rb
# OK: smoke/class_method.rb
# OK: smoke/constant1.rb
# OK: smoke/constant2.rb
# OK: smoke/demo.rb
# OK: smoke/demo1.rb
# OK: smoke/demo10.rb
# OK: smoke/demo11.rb
# OK: smoke/demo2.rb
# OK: smoke/demo3.rb
# OK: smoke/demo4.rb
# OK: smoke/demo5.rb
# OK: smoke/demo6.rb
# OK: smoke/demo7.rb
# OK: smoke/demo8.rb
# OK: smoke/demo9.rb
# OK: smoke/fib.rb
# OK: smoke/flow1.rb
# OK: smoke/flow2.rb
# OK: smoke/function.rb
# OK: smoke/gvar.rb
# OK: smoke/inheritance.rb
# OK: smoke/initialize.rb
# OK: smoke/int_times.rb
# OK: smoke/integer.rb
# OK: smoke/ivar.rb
# OK: smoke/masgn1.rb
# OK: smoke/masgn2.rb
# OK: smoke/masgn3.rb
# OK: smoke/optional1.rb
# OK: smoke/optional2.rb
# OK: smoke/proc.rb
# OK: smoke/range.rb
# OK: smoke/rest1.rb
# OK: smoke/rest2.rb
# OK: smoke/reveal.rb
# OK: smoke/super1.rb
# OK: smoke/super2.rb
# OK: smoke/svar1.rb
# OK: smoke/toplevel.rb
```


## after


```bash
$ ./smoke.sh 
# OK: smoke/alias.rb
# OK: smoke/any1.rb
# OK: smoke/any2.rb
# OK: smoke/arguments.rb
# OK: smoke/array-each.rb
# OK: smoke/array-each2.rb
# OK: smoke/array-each3.rb
# NG: smoke/array-plus1.rb
#<ArgumentError: wrong number of arguments (given 4, expected 3)>
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:124:in `deploy_array_type'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/builtin.rb:163:in `array_plus'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `[]'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `do_send_core'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:10:in `do_send'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:735:in `block (2 levels) in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each_key'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:734:in `block in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/type.rb:33:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:731:in `step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:607:in `type_profile'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler.rb:21:in `type_profile'
tools/run-smoke.rb:13:in `run'
tools/run-smoke.rb:25:in `block in <main>'
tools/run-smoke.rb:22:in `each'
tools/run-smoke.rb:22:in `<main>'
# NG: smoke/array-plus2.rb
#<ArgumentError: wrong number of arguments (given 4, expected 3)>
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:124:in `deploy_array_type'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/builtin.rb:163:in `array_plus'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `[]'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `do_send_core'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:10:in `do_send'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:735:in `block (2 levels) in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each_key'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:734:in `block in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/type.rb:33:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:731:in `step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:607:in `type_profile'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler.rb:21:in `type_profile'
tools/run-smoke.rb:13:in `run'
tools/run-smoke.rb:25:in `block in <main>'
tools/run-smoke.rb:22:in `each'
tools/run-smoke.rb:22:in `<main>'
# NG: smoke/array-pop.rb
#<NoMethodError: undefined method `[]' for #<TypeProfiler::Env:0x00005583e6315c08>>
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/builtin.rb:178:in `block in array_pop'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:44:in `each_key'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:44:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/builtin.rb:177:in `array_pop'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `[]'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `do_send_core'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:10:in `do_send'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:735:in `block (2 levels) in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each_key'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:734:in `block in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/type.rb:33:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:731:in `step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:607:in `type_profile'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler.rb:21:in `type_profile'
tools/run-smoke.rb:13:in `run'
tools/run-smoke.rb:25:in `block in <main>'
tools/run-smoke.rb:22:in `each'
tools/run-smoke.rb:22:in `<main>'
# OK: smoke/array1.rb
# OK: smoke/array2.rb
# OK: smoke/array3.rb
# OK: smoke/array4.rb
# OK: smoke/array5.rb
# OK: smoke/array6.rb
# OK: smoke/array7.rb
# OK: smoke/array8.rb
# OK: smoke/backtrace.rb
# OK: smoke/block1.rb
# NG: smoke/block10.rb
#<NoMethodError: undefined method `update' for nil:NilClass>
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:142:in `poke_array_elem_types'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/builtin.rb:139:in `array_aset'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `[]'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `do_send_core'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:10:in `do_send'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:735:in `block (2 levels) in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each_key'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:734:in `block in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/type.rb:33:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:731:in `step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:607:in `type_profile'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler.rb:21:in `type_profile'
tools/run-smoke.rb:13:in `run'
tools/run-smoke.rb:25:in `block in <main>'
tools/run-smoke.rb:22:in `each'
tools/run-smoke.rb:22:in `<main>'
# OK: smoke/block11.rb
# OK: smoke/block2.rb
# OK: smoke/block3.rb
# OK: smoke/block4.rb
# OK: smoke/block5.rb
# OK: smoke/block6.rb
# NG: smoke/block7.rb
#<NameError: undefined local variable or method `scratch' for TypeProfiler::Scratch::Aux:Module
Did you mean?  catch>
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:1254:in `setup_actual_arguments'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:730:in `step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:607:in `type_profile'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler.rb:21:in `type_profile'
tools/run-smoke.rb:13:in `run'
tools/run-smoke.rb:25:in `block in <main>'
tools/run-smoke.rb:22:in `each'
tools/run-smoke.rb:22:in `<main>'
# OK: smoke/block8.rb
# OK: smoke/block9.rb
# OK: smoke/case.rb
# OK: smoke/class_method.rb
# OK: smoke/constant1.rb
# OK: smoke/constant2.rb
# OK: smoke/demo.rb
# OK: smoke/demo1.rb
# OK: smoke/demo10.rb
# OK: smoke/demo11.rb
# OK: smoke/demo2.rb
# OK: smoke/demo3.rb
# OK: smoke/demo4.rb
# OK: smoke/demo5.rb
# OK: smoke/demo6.rb
# OK: smoke/demo7.rb
# OK: smoke/demo8.rb
# OK: smoke/demo9.rb
# OK: smoke/fib.rb
# OK: smoke/flow1.rb
# OK: smoke/flow2.rb
# OK: smoke/function.rb
# OK: smoke/gvar.rb
# OK: smoke/inheritance.rb
# OK: smoke/initialize.rb
# OK: smoke/int_times.rb
# OK: smoke/integer.rb
# OK: smoke/ivar.rb
# OK: smoke/masgn1.rb
# OK: smoke/masgn2.rb
# OK: smoke/masgn3.rb
# OK: smoke/optional1.rb
# OK: smoke/optional2.rb
# OK: smoke/proc.rb
# OK: smoke/range.rb
# OK: smoke/rest1.rb
# OK: smoke/rest2.rb
# NG: smoke/rest3.rb
#<ArgumentError: wrong number of arguments (given 4, expected 3)>
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:124:in `deploy_array_type'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/builtin.rb:163:in `array_plus'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `[]'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `do_send_core'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:10:in `do_send'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:735:in `block (2 levels) in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each_key'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:734:in `block in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/type.rb:33:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:731:in `step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:607:in `type_profile'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler.rb:21:in `type_profile'
tools/run-smoke.rb:13:in `run'
tools/run-smoke.rb:25:in `block in <main>'
tools/run-smoke.rb:22:in `each'
tools/run-smoke.rb:22:in `<main>'
# NG: smoke/rest4.rb
#<ArgumentError: wrong number of arguments (given 4, expected 3)>
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:124:in `deploy_array_type'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/builtin.rb:163:in `array_plus'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `[]'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:131:in `do_send_core'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/method.rb:10:in `do_send'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:735:in `block (2 levels) in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each_key'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/utils.rb:79:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:734:in `block in step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/type.rb:33:in `each'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:731:in `step'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler/analyzer.rb:607:in `type_profile'
/home/pocke/ghq/github.com/mame/ruby-type-profiler/lib/type-profiler.rb:21:in `type_profile'
tools/run-smoke.rb:13:in `run'
tools/run-smoke.rb:25:in `block in <main>'
tools/run-smoke.rb:22:in `each'
tools/run-smoke.rb:22:in `<main>'
# OK: smoke/reveal.rb
# OK: smoke/super1.rb
# OK: smoke/super2.rb
# OK: smoke/svar1.rb
# OK: smoke/toplevel.rb
```

## note

Actually the smoke test is failing. I guess the failing was concealed by the output swapping.

My environment:

```bash
$ ruby -v
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux]
```

